### PR TITLE
Use Google Books API and support CSV uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BookScout Extension
 
-A Chrome extension that recommends books using AI and Goodreads history.
+A Chrome extension that recommends books using Google Books and Goodreads history.
 
 ## Development
 
-1. Add your OpenAI API key and Goodreads API credentials in `popup.js`.
+1. Add your Google Books API key in `popup.js`.
 2. Load the extension in Chrome:
    - Open `chrome://extensions`
    - Enable **Developer Mode**
@@ -12,4 +12,4 @@ A Chrome extension that recommends books using AI and Goodreads history.
 
 ## Usage
 
-Describe what you'd like to read and optionally include your Goodreads history. The extension will list matching books with Amazon and Goodreads links.
+Describe what you'd like to read and optionally include your Goodreads history (open your Goodreads "My Books" page first) or upload a CSV of books you've read. The extension will list matching books with Amazon and Goodreads links.

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,10 @@
   "manifest_version": 3,
   "name": "BookScout",
   "version": "0.1.0",
-  "description": "Find book recommendations using AI and Goodreads history.",
-  "permissions": ["storage"],
+  "description": "Find book recommendations using Google Books and Goodreads history.",
+  "permissions": ["storage", "activeTab", "scripting"],
   "host_permissions": [
-    "https://api.openai.com/*",
-    "https://generativelanguage.googleapis.com/*",
-    "https://www.goodreads.com/*",
+    "https://www.googleapis.com/*",
     "https://www.amazon.com/*"
   ],
   "action": {

--- a/popup.html
+++ b/popup.html
@@ -17,6 +17,10 @@
     <div>
       <label><input type="checkbox" id="useHistory"/> Use Goodreads history</label>
     </div>
+    <div>
+      <label for="csvFile">Upload CSV of your books</label>
+      <input type="file" id="csvFile" accept=".csv" />
+    </div>
     <button type="submit">Search</button>
   </form>
   <div id="recommendations"></div>


### PR DESCRIPTION
## Summary
- switch extension to Google Books API and drop OpenAI and Goodreads API keys
- allow parsing Goodreads history via active tab
- add CSV upload of book lists and combine them with prompts for recommendations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f8257d104832a9c1ca0f1678fcb9e